### PR TITLE
refactor(share): Refactor Share button & minor adjustments

### DIFF
--- a/components/ItemManager.tsx
+++ b/components/ItemManager.tsx
@@ -128,8 +128,8 @@ const ItemManager: React.FC<ItemManagerProps> = ({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Add Items</DropdownMenuLabel>
+          <DropdownMenuLabel>Add Items</DropdownMenuLabel>
+          <DropdownMenuGroup className="mx-2">
             <DropdownMenuItem onSelect={() => setIsItemSetSelectorOpen(true)}>
               From template
             </DropdownMenuItem>

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -264,6 +264,5 @@ What do you think? 🤔
     </Popover>
   );
 };
-;
 
 export default ShareButton;

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -4,18 +4,24 @@ import html2canvasPro from 'html2canvas-pro';
 import Image from 'next/image';
 import {Button} from "@/components/ui/button"
 import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover"
-import {Share1Icon, CopyIcon, TwitterLogoIcon, QuestionMarkCircledIcon} from '@radix-ui/react-icons';
+import {Share1Icon, QuestionMarkCircledIcon, ImageIcon, CameraIcon} from '@radix-ui/react-icons';
 import {toast} from 'sonner';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select"
-import {Separator} from "@/components/ui/separator";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip";
-import {Collapsible, CollapsibleContent, CollapsibleTrigger} from "@/components/ui/collapsible";
 import {Skeleton} from "@/components/ui/skeleton";
+import {FaFacebookF, FaMarkdown, FaXTwitter} from "react-icons/fa6";
+import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs"
+import {Collapsible, CollapsibleContent, CollapsibleTrigger} from "@/components/ui/collapsible";
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
 
 type SocialPlatform = 'facebook' | 'twitter';
 type CaptureMethod = 'original' | 'pro';
 
-const ShareButton: React.FC = () => {
+interface ShareButtonProps {
+  title: string;
+}
+
+const ShareButton: React.FC<ShareButtonProps> = ({title}) => {
   const [imageBlob, setImageBlob] = useState<Blob | null>(null);
   const [captureMethod, setCaptureMethod] = useState<CaptureMethod>('pro');
   const [isCapturing, setIsCapturing] = useState(false);
@@ -66,7 +72,7 @@ const ShareButton: React.FC = () => {
         canvas = await html2canvasPro(element, {});
       }
 
-      canvas.toBlob((blob: React.SetStateAction<Blob | null>) => {
+      canvas.toBlob((blob: Blob | null) => {
         if (blob) setImageBlob(blob);
       }, 'image/png');
 
@@ -96,140 +102,168 @@ const ShareButton: React.FC = () => {
   };
 
   const shareToSocial = (platform: SocialPlatform) => {
-    copyImage();
-    const shareText = "Check out my tier list! [Paste image here]";
+    const shareText = `I've just ranked "${title}" on OpenTierBoy. What do you think? 🤔`;
     const url = platform === 'facebook'
       ? `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}&quote=${encodeURIComponent(shareText)}`
       : `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(window.location.href)}`;
 
     window.open(url, '_blank');
-    toast.success(`Sharing to ${platform}`, {
-      description: "Image copied. Please paste it into your post on the opened page."
-    });
   };
 
-  const handleCaptureMethodChange = (value: string) => {
-    setCaptureMethod(value as CaptureMethod);
-  };
+  const copyAsMarkdown = () => {
+    const shareText = `I've just ranked **${title}** on OpenTierBoy.
+What do you think? 🤔
+[Check it out on OpenTierBoy!](${window.location.href})
+-# The link is shortened for brevity. Always double-check before clicking! It should start with \`https://opentierboy.com/\`.
+`;
+    navigator.clipboard.writeText(shareText).then(() => {
+      toast.success('Markdown copied to clipboard', {
+        description: 'Share it on Discord or Telegram, or any other platform that supports markdown!'
+      });
+    }).catch(err => {
+      console.error('Error copying markdown: ', err);
+      toast.error('Failed to copy markdown');
+    });
+  }
 
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={captureImage}
-          disabled={isCapturing}
-        >
+        <Button variant="outline" size="icon" disabled={isCapturing}>
           <Share1Icon className="h-4 w-4"/>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[320px]" ref={popoverRef}>
-        <div className="grid gap-5">
-          <h3 className="scroll-m-20 text-xl font-semibold tracking-tight">
-            Share Your Rankings
-          </h3>
-          <div className="space-y-2">
-            <div className="flex flex-row space-x-2">
-              <h4 className="font-medium leading-none">As URL</h4>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <QuestionMarkCircledIcon className="h-4 w-4"/>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Consider using URL shorteners for ease of sharing.
-                    Images added from your device will be replaced with placeholders.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Copy the URL from the browser address bar to share the tier list. <i>Copy-jutsu!</i>
-            </p>
-          </div>
-          <Separator/>
-
-          <div>
-            <h4 className="font-medium leading-none">As Image</h4>
-            <Collapsible>
-              <CollapsibleTrigger className="text-[10px] underline underline-offset-1 decoration-dotted">
-                Options
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <p className="text-sm text-muted-foreground">
-                  Capturing images might be buggy. Please try one of the following methods or take a screenshot
-                  manually.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-2">
-                  <Select value={captureMethod} onValueChange={handleCaptureMethodChange}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select capture method"/>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="original">Original html2canvas</SelectItem>
-                      <SelectItem value="pro">html2canvas-pro</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Button onClick={captureImage} disabled={isCapturing} className="sm:w-auto">
-                    {isCapturing ? 'Capturing...' : 'Recapture'}
+        <h2 className="scroll-m-20 text-xl font-semibold tracking-tight mb-4">
+          Share Your Rankings
+        </h2>
+        <Tabs defaultValue="url">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="url">URL</TabsTrigger>
+            <TabsTrigger value="image">Image</TabsTrigger>
+          </TabsList>
+          <TabsContent value="url">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg space-x-2">
+                  <span>As URL</span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <QuestionMarkCircledIcon className="h-4 w-4"/>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Consider using URL shorteners for ease of sharing.
+                        Images added from your device will be replaced with placeholders.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  You may also copy the URL directly from your browser address bar to share your tier
+                  list. <br/>
+                  <i>Copy-jutsu!</i>
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-center">
+                  <Button variant="outline" onClick={copyAsMarkdown}>
+                    <FaMarkdown className="mr-2"/> Copy Markdown
                   </Button>
                 </div>
-              </CollapsibleContent>
-            </Collapsible>
-          </div>
-          {imageBlob ? (
-            <div className="relative w-full h-48">
-              <Image
-                src={URL.createObjectURL(imageBlob)}
-                alt="Captured tier list"
-                fill
-                style={{objectFit: "contain"}}
-              />
-            </div>
-          ) : (
-            <div className="flex items-center">
-              <div className="space-y-2">
-                <p className="text-center italic">Freeze frame!</p>
-                <Skeleton className="h-6 w-[280px]"/>
-                <Skeleton className="h-6 w-[280px]"/>
-                <Skeleton className="h-6 w-[280px]"/>
-              </div>
-            </div>
-          )}
-          <div>
-            <p className="text-sm text-muted-foreground text-right">
-              If sharing on social media, remember to paste the copied image into your post.
-            </p>
-            <p className="text-[8px] text-muted-foreground text-right">
-              (it isn&apos;t automatic)
-            </p>
-          </div>
-          <div className="flex justify-end space-x-1">
-            <Button variant="outline" size="icon" onClick={copyImage} disabled={!imageBlob}>
-              <CopyIcon className="h-4 w-4"/>
-            </Button>
-            <a href="#" onClick={(e) => {
-              e.preventDefault();
-              shareToSocial('facebook');
-            }}>
-              <Button variant="outline" size="icon" disabled={!imageBlob}>
-                FB
-              </Button>
-            </a>
-            <a href="#" onClick={(e) => {
-              e.preventDefault();
-              shareToSocial('twitter');
-            }}>
-              <Button variant="outline" size="icon" disabled={!imageBlob}>
-                <TwitterLogoIcon className="h-4 w-4"/>
-              </Button>
-            </a>
-          </div>
-        </div>
+                <div className="flex justify-center text-sm text-muted-foreground">
+                  OR
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <div className="flex flex-row space-x-2">
+                    <Button variant="outline" size="icon" onClick={() => shareToSocial('facebook')}>
+                      <FaFacebookF className="h-4 w-4"/>
+                    </Button>
+                    <Button variant="outline" size="icon" onClick={() => shareToSocial('twitter')}>
+                      <FaXTwitter className="h-4 w-4"/>
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="image">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">As Image</CardTitle>
+                <Collapsible>
+                  <CollapsibleTrigger className="text-[10px] underline underline-offset-1 decoration-dotted">
+                    Options
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <p className="text-sm text-muted-foreground">
+                      Capturing images might be buggy. Please try one of the following methods or take a screenshot
+                      manually.
+                    </p>
+                    <div className="flex flex-col sm:flex-row gap-2">
+                      <Select value={captureMethod} onValueChange={(value: CaptureMethod) => setCaptureMethod(value)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select capture method"/>
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="original">Original html2canvas</SelectItem>
+                          <SelectItem value="pro">html2canvas-pro</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-center">
+                  <Button onClick={captureImage} disabled={isCapturing} className="sm:w-auto">
+                    <CameraIcon className="mr-2"/>
+                    {isCapturing ? 'Capturing...' : 'Capture Preview'}
+                  </Button>
+                </div>
+
+                {imageBlob && (
+                  <div className="relative w-full h-48">
+                    <Image
+                      src={URL.createObjectURL(imageBlob)}
+                      alt="Captured tier list"
+                      fill
+                      style={{objectFit: "contain"}}
+                    />
+                  </div>
+                )}
+
+                {isCapturing && (
+                  <div className="flex items-center">
+                    <div className="space-y-2 w-full">
+                      <p className="text-center italic">Freeze frame!</p>
+                      <Skeleton className="h-6 w-full"/>
+                      <Skeleton className="h-6 w-full"/>
+                      <Skeleton className="h-6 w-full"/>
+                    </div>
+                  </div>
+                )}
+
+                {imageBlob ? (
+                  <div className="flex justify-center">
+                    <Button variant="outline" onClick={copyImage} disabled={!imageBlob}>
+                      <ImageIcon className="mr-2"/>
+                      Copy Image
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex justify-center text-sm text-muted-foreground">
+                    Capture an image to get started.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
       </PopoverContent>
     </Popover>
   );
 };
+;
 
 export default ShareButton;

--- a/components/TierListManager.tsx
+++ b/components/TierListManager.tsx
@@ -169,7 +169,7 @@ const TierListManager: React.FC<TierListManagerProps> = ({initialItemSet, initia
   return (
     <TierContext.Provider value={contextValue}>
       <div className="mb-4">
-        <EditableLabel as="h2" text={name} onSave={setName} placeholder="Enter title"
+        <EditableLabel as="h1" text={name} onSave={setName} placeholder="Enter title"
                        contentClassName="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0 text-center"/>
       </div>
       <div className="flex flex-col items-center hide-in-zen">
@@ -183,7 +183,7 @@ const TierListManager: React.FC<TierListManagerProps> = ({initialItemSet, initia
             undoReset={undoReset}
             undoDelete={undoDelete}
           />
-          <ShareButton/>
+          <ShareButton title={name}/>
         </div>
         <div className="p-2" data-html2canvas-ignore>
           <p className="text-sm text-muted-foreground text-center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.52.0",
+        "react-icons": "^5.2.1",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
@@ -8216,6 +8217,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.52.0",
+    "react-icons": "^5.2.1",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
### Fixes: #51

### Description

Revamps the Share button UX with OG-image consideration.

Also tweaks `ItemManager` "Add Item" heading.

### Screenshots

<img width="328" alt="image" src="https://github.com/user-attachments/assets/aa18e624-28ce-446f-b4df-1f063203d139">

<img width="351" alt="image" src="https://github.com/user-attachments/assets/87b3c4dd-5c67-4347-a5e1-2f4162416d31">


### Checklist:

- [x] My changes generate no new warnings or errors
- [x] The build passes successfully
- [x] I have tested these changes locally
- [x] I have updated the documentation as necessary
- [x] I have verified that these changes don't negatively impact performance

### Additional context

May optimize Social post content further in later iterations.
