### PR TITLE
feat(UI): Hide Zen toggle on non-rank pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We welcome contributions to OpenTierBoy! Whether you're fixing bugs, adding new 
 sets, your input is valuable.
 
 For detailed information on how to contribute, including guidelines for code contributions and instructions for
-submitting new image sets, please see our CONTRIBUTING.md file.
+submitting new image sets, please see our [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## 🐛 Reporting Issues
 

--- a/app/(static)/about/page.tsx
+++ b/app/(static)/about/page.tsx
@@ -3,6 +3,7 @@ import {Card, CardContent, CardHeader} from "@/components/ui/card";
 import {Button} from "@/components/ui/button";
 import {DiscordLogoIcon, GitHubLogoIcon} from "@radix-ui/react-icons";
 import Image from "next/image";
+import otbLogo from "@/public/brand/otb-logo-wide.webp";
 
 const AboutPage = () => {
   return (
@@ -10,8 +11,8 @@ const AboutPage = () => {
       {/* Hero Section */}
       <section className="container mx-auto px-4 py-20 text-center">
         <h1 className="text-2xl md:text-3xl font-light mb-12 flex flex-col justify-center">
-          <div className="flex justify-center mb-6">
-            <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={600} height={200} priority/>
+          <div className="flex justify-center mb-6 max-w-[600]">
+            <Image src={otbLogo} alt="OpenTierBoy" priority/>
           </div>
           Craft, rank and share your passion - the open-source way!
         </h1>

--- a/app/(static)/about/page.tsx
+++ b/app/(static)/about/page.tsx
@@ -11,7 +11,7 @@ const AboutPage = () => {
       <section className="container mx-auto px-4 py-20 text-center">
         <h1 className="text-2xl md:text-3xl font-light mb-12 flex flex-col justify-center">
           <div className="flex justify-center mb-6">
-            <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={600} height={200}/>
+            <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={600} height={200} priority/>
           </div>
           Craft, rank and share your passion - the open-source way!
         </h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
         <div className="max-w-screen-lg mx-auto px-4">
           <div className="flex flex-row py-4 justify-between items-center">
             <a href="/" className="text-xl font-heading">
-              <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={150} height={50}/>
+              <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={150} height={40} priority/>
             </a>
             <div className="flex justify-center space-x-1">
               <ZenToggle/>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import {EnvelopeClosedIcon, GitHubLogoIcon} from "@radix-ui/react-icons";
 import {Button} from "@/components/ui/button";
 import Image from "next/image";
 import {FaDiscord} from "react-icons/fa6";
+import otbLogo from "@/public/brand/otb-logo-wide.webp";
 
 const fontSans = FontSans({
   subsets: ["latin"],
@@ -63,8 +64,8 @@ export default function RootLayout({
       <header className="w-full border-b" data-html2canvas-ignore>
         <div className="max-w-screen-lg mx-auto px-4">
           <div className="flex flex-row py-4 justify-between items-center">
-            <a href="/" className="text-xl font-heading">
-              <Image src="/brand/otb-logo-wide.webp" alt="OpenTierBoy" width={150} height={40} priority/>
+            <a href="/" className="text-xl font-heading ">
+              <Image src={otbLogo} alt="OpenTierBoy" height={40} priority/>
             </a>
             <div className="flex justify-center space-x-1">
               <ZenToggle/>

--- a/components/ZenToggle.tsx
+++ b/components/ZenToggle.tsx
@@ -4,9 +4,11 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {ReaderIcon} from "@radix-ui/react-icons";
 import {Toggle} from "@/components/ui/toggle";
 import {toast} from "sonner";
+import {usePathname} from "next/navigation";
 
 export function ZenToggle() {
   const [isZenMode, setIsZenMode] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     // Check initial state
@@ -26,6 +28,8 @@ export function ZenToggle() {
 
     toast(zenModeMessage, zenModeData);
   }, []);
+
+  if (!pathname.includes('rank')) return null;
 
   return (
     <Toggle


### PR DESCRIPTION
### Fixes: #56

### Description

This PR:
- Hides Zen toggle
- Tweaks brand Images to optimize for CLS
- Adds Readme Contributing link

