### PR TITLE
feat(ui): scrollbars on item creator

### DIFF
--- a/components/ItemCreator.tsx
+++ b/components/ItemCreator.tsx
@@ -74,7 +74,7 @@ const ItemCreator: React.FC<ItemCreatorProps> = ({onItemsCreate}) => {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col overflow-y-hidden">
         <FormField
           control={form.control}
           name="files"
@@ -100,7 +100,7 @@ const ItemCreator: React.FC<ItemCreatorProps> = ({onItemsCreate}) => {
             </FormItem>
           )}
         />
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4 overflow-y-auto pe-6">
           {uploadedItems.map((item) => (
             <div key={item.id} className="space-y-2">
               <div className="w-28 h-28 relative">

--- a/components/ItemManager.tsx
+++ b/components/ItemManager.tsx
@@ -174,7 +174,7 @@ const ItemManager: React.FC<ItemManagerProps> = ({
       </DropdownMenu>
 
       <Dialog open={isItemCreatorOpen} onOpenChange={setIsItemCreatorOpen}>
-        <DialogContent>
+        <DialogContent className="max-h-[80vh] overflow-hidden flex flex-col">
           <DialogHeader>
             <DialogTitle>Add New Items</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
### Description

When too many images are added at once, the form overflows off the screen, blocking access to the form buttons. This PR limits the size of the form and causes the inner `ItemCreator` to scroll if neccessary.

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/1d6a0b0d-b26a-4aa2-ad71-de13aa0f2c42)


#### After
![image](https://github.com/user-attachments/assets/8283749f-ab56-40be-b983-b9184dd8a313)


### Checklist:

- [x] My changes generate no new warnings or errors
- [x] The build passes successfully
- [x] I have verified that these changes don't negatively impact performance
- [x] Also optimized for mobile layouts
