### PR TITLE
chore(asset/helldivers2): Bump Helldivers 2 images

### DIFF
--- a/imageset.config.json
+++ b/imageset.config.json
@@ -3041,6 +3041,20 @@
           ]
         },
         {
+          "filename": "cqc19stunlance.webp",
+          "label": "Stun Lance",
+          "tags": [
+            "Secondaries"
+          ]
+        },
+        {
+          "filename": "cqc30stunbaton.webp",
+          "label": "Stun Baton",
+          "tags": [
+            "Secondaries"
+          ]
+        },
+        {
           "filename": "deadsprint.webp",
           "label": "Dead Sprint",
           "tags": [
@@ -3097,6 +3111,13 @@
           ]
         },
         {
+          "filename": "eat12antitankemplacement.webp",
+          "label": "Anti-Tank Emplacement",
+          "tags": [
+            "Stratagems"
+          ]
+        },
+        {
           "filename": "eat17expendableantitank.webp",
           "label": "Expendable Anti-Tank",
           "tags": [
@@ -3146,6 +3167,13 @@
           ]
         },
         {
+          "filename": "fastreconvehicle.webp",
+          "label": "Fast Recon Vehicle",
+          "tags": [
+            "Stratagems"
+          ]
+        },
+        {
           "filename": "firebombhellpods.webp",
           "label": "Firebomb Hellpods",
           "tags": [
@@ -3164,6 +3192,13 @@
           "label": "Torcher",
           "tags": [
             "Primaries"
+          ]
+        },
+        {
+          "filename": "flamesentry.webp",
+          "label": "Flame Sentry",
+          "tags": [
+            "Stratagems"
           ]
         },
         {
@@ -3566,6 +3601,13 @@
           ]
         },
         {
+          "filename": "plas39acceleratorrifle.webp",
+          "label": "Accelerator Rifle",
+          "tags": [
+            "Primaries"
+          ]
+        },
+        {
           "filename": "r2124constitution.webp",
           "label": "Constitution",
           "tags": [
@@ -3692,6 +3734,13 @@
           ]
         },
         {
+          "filename": "sh51directionalshield.webp",
+          "label": "Directional Shield",
+          "tags": [
+            "Stratagems"
+          ]
+        },
+        {
           "filename": "shieldgeneratorrelay.webp",
           "label": "Shield Relay",
           "tags": [
@@ -3715,6 +3764,20 @@
         {
           "filename": "smg72pummeler.webp",
           "label": "Pummeler",
+          "tags": [
+            "Primaries"
+          ]
+        },
+        {
+          "filename": "sta11smg.webp",
+          "label": "StA-11 SMG",
+          "tags": [
+            "Primaries"
+          ]
+        },
+        {
+          "filename": "sta52assaultrifle.webp",
+          "label": "StA-52 Assault Rifle",
           "tags": [
             "Primaries"
           ]
@@ -3766,6 +3829,11 @@
           "description": "Images of Helldivers 2 primary weapons",
           "category": "general"
         },
+        "Secondaries": {
+          "title": "Secondaries",
+          "description": "Images of Helldivers 2 secondary weapons",
+          "category": "general"
+        },
         "Boosters": {
           "title": "Boosters",
           "description": "Images of Helldivers 2 boosters",
@@ -3774,11 +3842,6 @@
         "Grenades": {
           "title": "Grenades",
           "description": "Images of Helldivers 2 grenades",
-          "category": "general"
-        },
-        "Secondaries": {
-          "title": "Secondaries",
-          "description": "Images of Helldivers 2 secondary weapons",
           "category": "general"
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "gray-matter": "^4.0.3",
         "html2canvas": "^1.4.1",
         "html2canvas-pro": "^1.5.8",
-        "image-helldivers2": "^3.4.2",
+        "image-helldivers2": "4.0.0",
         "image-overwatch": "^1.1.0",
         "image-reachthefinals": "^1.1.1",
         "image-set": "^2.1.0",
@@ -5854,9 +5854,9 @@
       }
     },
     "node_modules/image-helldivers2": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/image-helldivers2/-/image-helldivers2-3.4.2.tgz",
-      "integrity": "sha512-7PMC2CCPjexrhDgPg3f6WGPHqnuC6sSs0XdyL+TDVTZ3rb0DqmBZ7KxegVeDFL4+vbj37XQPldM1eVGA/bN6pw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-helldivers2/-/image-helldivers2-4.0.0.tgz",
+      "integrity": "sha512-v2kl59FJjqlhlJkTBiFV/yVmLvViZx0CdRGpdEG9zW1jD05xOokQhm9l8b7teVUbr3fKm1Dxt+dqkpgGGf2dyg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "gray-matter": "^4.0.3",
         "html2canvas": "^1.4.1",
         "html2canvas-pro": "^1.5.8",
-        "image-helldivers2": "^3.3.2",
+        "image-helldivers2": "^3.4.2",
         "image-overwatch": "^1.1.0",
         "image-reachthefinals": "^1.1.1",
         "image-set": "^2.1.0",
@@ -5854,9 +5854,9 @@
       }
     },
     "node_modules/image-helldivers2": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/image-helldivers2/-/image-helldivers2-3.3.2.tgz",
-      "integrity": "sha512-2SqfVu7OVO3ichMQshr4kk3AOollXy4+uGOARJdFlcNk2y/mK5VtQoDSx1Jw5sBvR5FPfOJDlrLDod6CfkqyVw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/image-helldivers2/-/image-helldivers2-3.4.2.tgz",
+      "integrity": "sha512-7PMC2CCPjexrhDgPg3f6WGPHqnuC6sSs0XdyL+TDVTZ3rb0DqmBZ7KxegVeDFL4+vbj37XQPldM1eVGA/bN6pw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.1.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gray-matter": "^4.0.3",
     "html2canvas": "^1.4.1",
     "html2canvas-pro": "^1.5.8",
-    "image-helldivers2": "^3.4.2",
+    "image-helldivers2": "4.0.0",
     "image-overwatch": "^1.1.0",
     "image-reachthefinals": "^1.1.1",
     "image-set": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gray-matter": "^4.0.3",
     "html2canvas": "^1.4.1",
     "html2canvas-pro": "^1.5.8",
-    "image-helldivers2": "^3.3.2",
+    "image-helldivers2": "^3.4.2",
     "image-overwatch": "^1.1.0",
     "image-reachthefinals": "^1.1.1",
     "image-set": "^2.1.0",


### PR DESCRIPTION
### Fixes: Outdated image-helldivers2 NPM package

### Description

Bump image-helldivers2 NPM package to 4.0.0. Adding the latest equipment and stratagems.

### Checklist:

- [x] My changes generate no new warnings or errors
- [x] I have verified that these changes don't negatively impact performance
- [x] Also optimized for mobile layouts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new images for secondary weapons: "Stun Lance" and "Stun Baton."
	- Introduced additional images: "Anti-Tank Emplacement," "Fast Recon Vehicle," "Flame Sentry," "Accelerator Rifle," "Directional Shield," "StA-11 SMG," and "StA-52 Assault Rifle."
	- Updated categorization for secondary weapons with a new tag.

- **Bug Fixes**
	- Updated dependency version for `image-helldivers2` to ensure compatibility with new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->