### PR TITLE
fix(ui): Label Position Resets After Changing Number of Rows

### DIFF
--- a/components/TierListManager.tsx
+++ b/components/TierListManager.tsx
@@ -41,22 +41,24 @@ const TierListManager: React.FC<TierListManagerProps> = ({initialItemSet, initia
 
   useEffect(() => {
     const state = searchParams.get('state');
-    if (state) {
-      const decodedState = tierCortex.decodeTierStateFromURL(state);
-      if (decodedState) {
-        if (decodedState.title) {
-          setName(decodedState.title);
-        }
-        
-        decodedState.tiers.forEach(tier => {
-          tier.labelPosition = labelPosition;
-        });
-        
-        setTiers(decodedState.tiers);
+    if (!state) return;
 
-        setUrlLength(pathname.length + state.length + 7); // 7 is the length of "?state="
-      }
+    const decodedState = tierCortex.decodeTierStateFromURL(state);
+    if (!decodedState) return;
+
+    // Update name if present
+    if (decodedState.title) {
+      setName(decodedState.title);
     }
+
+    // Updated label positions
+    const updatedTiers = decodedState.tiers.map(tier => ({
+      ...tier,
+      labelPosition
+    }));
+
+    setTiers(updatedTiers);
+    setUrlLength(pathname.length + state.length + 7); // 7 is the length of "?state="
   }, [pathname.length, searchParams, tierCortex, labelPosition]);
 
   const handleTiersUpdate = useCallback((updatedTiers: Tier[]) => {

--- a/components/TierListManager.tsx
+++ b/components/TierListManager.tsx
@@ -47,12 +47,17 @@ const TierListManager: React.FC<TierListManagerProps> = ({initialItemSet, initia
         if (decodedState.title) {
           setName(decodedState.title);
         }
+        
+        decodedState.tiers.forEach(tier => {
+          tier.labelPosition = labelPosition
+        });
+        
         setTiers(decodedState.tiers);
 
         setUrlLength(pathname.length + state.length + 7); // 7 is the length of "?state="
       }
     }
-  }, [pathname.length, searchParams, tierCortex]);
+  }, [pathname.length, searchParams, tierCortex, labelPosition]);
 
   const handleTiersUpdate = useCallback((updatedTiers: Tier[]) => {
     previousTiersRef.current = updatedTiers;

--- a/components/TierListManager.tsx
+++ b/components/TierListManager.tsx
@@ -49,7 +49,7 @@ const TierListManager: React.FC<TierListManagerProps> = ({initialItemSet, initia
         }
         
         decodedState.tiers.forEach(tier => {
-          tier.labelPosition = labelPosition
+          tier.labelPosition = labelPosition;
         });
         
         setTiers(decodedState.tiers);


### PR DESCRIPTION
### Description

When you change the label position to right or top, then change the number of rows, the label position reverted to Left.

This was because changing the number of rows updates the search params, which in turn triggers the `useEffect()` that reloads the tier list with the new search param data. This data doesn't include the label position, so it was defaulting to left.

Fixed by assigning the `labelPosition` on the search param data tiers before the call to `setTiers()`.

### Screenshots

**Before**

https://github.com/user-attachments/assets/735210d4-1a0c-4db5-b8bd-96e2e33ec0e3

**After**

https://github.com/user-attachments/assets/f4820f68-560e-41e4-8d93-10bfd3a399cb

### Checklist:

- [x] My changes generate no new warnings or errors
- [x] I have verified that these changes don't negatively impact performance
- [x] Also optimized for mobile layouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for tier state decoding from the URL.
	- Ensured consistent label positioning across tier list updates.
	- Improved dynamic updates to the tier list based on user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->