### PR TITLE
fix(ui): Tier List Data Doesn't Reset When Changing Tier List

### DIFF
--- a/lib/TierCortex.ts
+++ b/lib/TierCortex.ts
@@ -150,18 +150,18 @@ export class TierCortex {
       if (decodedState) return decodedState.tiers;
     }
 
+    const initialTiers: Tier[] = JSON.parse(JSON.stringify(DEFAULT_TIER_TEMPLATE));
+
     if (initialItemSet) {
-      const initialTiers = [...DEFAULT_TIER_TEMPLATE];
       const lastTierIndex = initialTiers.length - 1;
 
       initialTiers[lastTierIndex].items = initialItemSet.images.map((filename) => {
         const itemId = `${initialItemSet.packageName}-${filename}`;
         return this.packageItemLookup[itemId] || this.createPlaceholderItem(itemId, filename);
       });
-      return initialTiers;
     }
 
-    return DEFAULT_TIER_TEMPLATE;
+    return initialTiers;
   }
 
   public getOgSafeImageUrl(url: string): string {

--- a/models/Tier.ts
+++ b/models/Tier.ts
@@ -10,7 +10,7 @@ export default interface Tier {
   placeholder?: string;
 }
 
-export type TierTemplate = Record<string, Tier[]>;
+export type TierTemplate = Record<string, Readonly<Tier>[]>;
 
 export const tierTemplates: TierTemplate = {
   '3rows': [


### PR DESCRIPTION
### Description

If you start a tier list, then go back and start another tier list, data gets carried over unexpectedly.

The cause is that when initializing a tier list, a shallow copy of the `DEFAULT_TIER_TEMPLATE` is used. When you edit the tier list, it ends up mutating the template tiers, which causes these edits to carry over to the next tier list you start.

Fixed by using a deep copy of `DEFAULT_TIER_TEMPLATE`.

### Screenshots

**Before**

https://github.com/user-attachments/assets/777a7143-609c-4c4c-8969-3fb14541ebe7

**After**

https://github.com/user-attachments/assets/2155906c-ef03-4d36-a4e5-7e50b991d1a7

### Checklist:

- [x] My changes generate no new warnings or errors
- [x] I have verified that these changes don't negatively impact performance
- [x] Also optimized for mobile layouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tier initialization process with improved immutability and type safety.

- **Refactor**
	- Updated `TierTemplate` type to enforce read-only tier objects.
	- Improved `getInitialTiers` method to create independent tier instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->