### PR TITLE
fix(ui): Visual Bugs When Dragging Items Into Empty Tiers

### DIFF
--- a/components/DragDropTierList.tsx
+++ b/components/DragDropTierList.tsx
@@ -39,7 +39,7 @@ const TierItems = memo<{
         <div
           ref={provided.innerRef}
           {...provided.droppableProps}
-          className={`w-full flex flex-wrap p-0 rounded-md ${snapshot.isDraggingOver ? 'ring-1 ring-accent-foreground' : ''}`}
+          className={`w-full min-h-16 md:min-h-20 flex flex-wrap gap-1 m-0.5 p-0 rounded-md ${snapshot.isDraggingOver ? 'ring-1 ring-accent-foreground' : ''}`}
         >
           {tier.items.map((item, itemIndex) => (
             <Draggable key={item.id} draggableId={item.id} index={itemIndex}>
@@ -49,7 +49,7 @@ const TierItems = memo<{
                   {...provided.draggableProps}
                   {...provided.dragHandleProps}
                   className={`
-                    m-0.5 rounded-md 
+                    rounded-md
                     ${snapshot.isDragging ? 'shadow-md ring-2' : ''}
                   `}
                   style={{
@@ -116,7 +116,7 @@ const TierRow = memo<{
             <div
               className={`flex ${labelPosition === 'left' ? 'flex-row' : labelPosition === 'right' ? 'flex-row-reverse' : 'flex-col'} items-center`}>
               {(labelPosition === 'left' || labelPosition === 'right') && (
-                <div className="w-18 md:w-40">
+                <div className="md:w-40">
                   <EditableLabel
                     text={tier.name}
                     onSave={(newText) => onSaveLabel(index, newText)}

--- a/components/DragDropTierList.tsx
+++ b/components/DragDropTierList.tsx
@@ -39,7 +39,7 @@ const TierItems = memo<{
         <div
           ref={provided.innerRef}
           {...provided.droppableProps}
-          className={`w-full min-h-16 md:min-h-20 flex flex-wrap gap-1 m-0.5 p-0 rounded-md ${snapshot.isDraggingOver ? 'ring-1 ring-accent-foreground' : ''}`}
+          className={`w-full min-h-17 md:min-h-21 flex flex-wrap p-0 rounded-md ${snapshot.isDraggingOver ? 'ring-1 ring-accent-foreground' : ''}`}
         >
           {tier.items.map((item, itemIndex) => (
             <Draggable key={item.id} draggableId={item.id} index={itemIndex}>
@@ -49,7 +49,7 @@ const TierItems = memo<{
                   {...provided.draggableProps}
                   {...provided.dragHandleProps}
                   className={`
-                    rounded-md
+                    m-0.5 rounded-md
                     ${snapshot.isDragging ? 'shadow-md ring-2' : ''}
                   `}
                   style={{

--- a/components/DragDropTierList.tsx
+++ b/components/DragDropTierList.tsx
@@ -91,6 +91,7 @@ const TierRow = memo<{
           {...provided.draggableProps}
           className={`
             border rounded-md min-w-full sm:min-w-[500px] md:min-w-[600px] lg:min-w-[800px] 
+            min-h-20
             flex items-center
             ${snapshot.isDragging ? 'shadow-lg ring-2' : ''}
           `}

--- a/components/DragDropTierList.tsx
+++ b/components/DragDropTierList.tsx
@@ -91,7 +91,6 @@ const TierRow = memo<{
           {...provided.draggableProps}
           className={`
             border rounded-md min-w-full sm:min-w-[500px] md:min-w-[600px] lg:min-w-[800px] 
-            min-h-20
             flex items-center
             ${snapshot.isDragging ? 'shadow-lg ring-2' : ''}
           `}

--- a/components/ItemTile.tsx
+++ b/components/ItemTile.tsx
@@ -54,7 +54,7 @@ const ItemTile: React.FC<ItemTileProps> = memo(({
   const handleDelete = useCallback(() => onDelete(id), [id, onDelete]);
 
   const tileContent = (
-    <div className="relative w-16 h-16 sm:w-18 sm:h-18 md:w-20 md:h-20 overflow-hidden rounded-md">
+    <div className="relative w-16 h-16 md:w-20 md:h-20 overflow-hidden rounded-md">
       {imageUrl ? (
         <>
           <div className="absolute inset-0 overflow-hidden">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,10 @@ const config = {
       },
     },
     extend: {
+      spacing: {
+        "17": "4.25rem",
+        "21": "5.25rem",
+      },
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],
         heading: ["var(--font-heading)", ...fontFamily.sans],


### PR DESCRIPTION
### Description

This small refactor of the tier list CSS fixes 2 bugs:

- Empty tiers are just slightly smaller than tiers with 1 row of items. When dragging an item over an empty tier, the tier expands to the correct size.
- When releasing an item into an empty tier, it transitions to below where it's supposed to go, then snaps to the correct position.

Removed `w-18` and `h-18` classes as they are not valid tailwind classses and thus had no effect. For example, (https://tailwindcss.com/docs/width) has `w-16` and `w-20`, but not `w-18`.

### Screenshots

**Before**

https://github.com/user-attachments/assets/b6146750-2e6a-4bf3-8b86-7ba5fd1d163e

**After**

https://github.com/user-attachments/assets/dd69afa7-3e6c-4ffd-b614-407ccc957645

### Checklist:

- [x] My changes generate no new warnings or errors
- [x] I have verified that these changes don't negatively impact performance
- [x] Also optimized for mobile layouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Updated responsive styling for drag-and-drop tier list components.
	- Adjusted layout and spacing for tier items and rows.
	- Simplified responsive design for item tiles on smaller screens.
	- Introduced new spacing values for enhanced layout control in Tailwind CSS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->